### PR TITLE
adding fix for dnsmasq bug with my target platform

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,13 +6,15 @@ BIN_INSTALL_DIR=/usr/local/bin
 
 #install packages
 sudo apt update
-
+'''
 if [[ -z `which hostapd` ]]; then
 	sudo apt install -y hostapd
 fi
 if [[ -z `which dnsmasq` ]]; then
 	sudo apt install -y dnsmasq
 fi
+'''
+sudo apt install -y hostapd dnsmasq netfilter-persistent iptables-persistent
 sudo DEBIAN_FRONTEND=noninteractive apt install -y netfilter-persistent iptables-persistent
 #DNMSAQ BK
 sudo cp -rf $CONFIG_INSTALL_DIR/dhcpcd.conf $CONFIG_INSTALL_DIR/dhcpcd.conf.bk $CONFIG_INSTALL_DIR/dhcpcd.conf.bk.org
@@ -22,4 +24,12 @@ cp -rf $SETUP_FILES_DIR/hostapd/* $CONFIG_INSTALL_DIR/hostapd/
 chmod 777 ./*.sh
 ln -s $SETUP_FILES_DIR/start_ap.sh $BIN_INSTALL_DIR
 echo "start_ap.sh" >> /etc/rc.local
-
+systemctl stop hostapd
+systemctl enable hostapd
+systemctl start hostapd
+systemctl stop dnsmasq
+sudo systemctl stop systemd-resolved
+sudo systemctl disable systemd-resolved
+sudo systemctl mask systemd-resolved
+sudo apt-get install --reinstall resolvconf
+sudo apt-get remove --purge resolvconf && sudo apt-get install resolvconf


### PR DESCRIPTION
I added a fix for a Dnsmasq bug with my target platform a Rpi 0w running Ubuntu server 22.04 LTS. lines 31-35 autofix the bug of giving me the errors:
dnsmasq: failed to create listening socket for port 53: Address already in use
and
dnsmasq: directory /etc/resolv.conf for resolv-file is missing, cannot poll

I suggest you make a new branch for edits because the bug was pretty circumstantial to how the default Ubuntu server environment is made. 

Thank you for your time, and have a good day